### PR TITLE
fixed update table in standalone mode bug

### DIFF
--- a/src/eventql/config/config_directory_standalone.cc
+++ b/src/eventql/config/config_directory_standalone.cc
@@ -206,7 +206,7 @@ void StandaloneConfigDirectory::updateTableConfig(
     bool force /* = false */) {
   std::unique_lock<std::mutex> lk(mutex_);
   auto table_id = table.customer() + "~" + table.table_name();
-  if (tables_.find(table_id) != tables_.end()) {
+  if (table.version() == 0 && tables_.find(table_id) != tables_.end()) {
     RAISEF(
         kIllegalArgumentError,
         "table already exists: $0",

--- a/src/eventql/db/table_service.cc
+++ b/src/eventql/db/table_service.cc
@@ -335,6 +335,8 @@ Status TableService::alterTable(
     }
   }
 
+  td.set_version(td.version() + 1);
+
   try {
     cdir_->updateTableConfig(td);
   } catch (const Exception& e) {


### PR DESCRIPTION
-- don't check if table already exists when table schema schould be updated (version > 0)